### PR TITLE
Support some more RC versions

### DIFF
--- a/plugin/src/main/kotlin/com/louiscad/complete_kotlin/internal/MetaVersion.kt
+++ b/plugin/src/main/kotlin/com/louiscad/complete_kotlin/internal/MetaVersion.kt
@@ -9,6 +9,9 @@ enum class MetaVersion(val metaString: String) {
     M2("M2"),
     RC("RC"),
     RC2("RC2"),
+    RC3("RC3"),
+    RC4("RC4"),
+    RC5("RC5"),
     PUB("PUB"),
     RELEASE("release");
 


### PR DESCRIPTION
Since Kotlin 2.0.0-RC3 is out, the plugin broke because RC3 isn't an accepted meta version